### PR TITLE
fix: Don't try to read data file when it does not exist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -543,11 +543,11 @@ fn show(tail: usize, wrap: usize, args: &Args) -> Result<(), String> {
 
 fn status(args: &Args) -> Result<(), String> {
     let path = ClockinTimestamp::relative_path(&args.namespace);
-    let clockin_timestamp: ClockinTimestamp = read_data_file(&path)?;
 
     if !data_file_exists(&path).unwrap() {
         println!("Clock is not running for namespace '{}'", args.namespace);
     } else {
+        let clockin_timestamp: ClockinTimestamp = read_data_file(&path)?;
         let duration: HumanDuration = (now() - clockin_timestamp.start_time).into();
         println!("Clock running for namespace '{}':", args.namespace);
         println!("\t started {}", clockin_timestamp.start_time);


### PR DESCRIPTION
Currently, the check whether the data path exists is done *after* trying to read from it.
This results in the following unhelpful error message `Error: Path not found` instead of the already existing `Clock is not running for namespace '{}'` message.
Fixing this is as simple as moving the file reading step below the existence check, which is what this PR accomplishes.